### PR TITLE
[BUGFIX] Check if array keys exist

### DIFF
--- a/Classes/Controller/WizardController.php
+++ b/Classes/Controller/WizardController.php
@@ -159,6 +159,9 @@ class WizardController extends NewContentElementController
     protected function keepOnlyListTypeAndCTypeInDefaultValues(array $wizards): array
     {
         foreach($wizards as $index => $wizard) {
+            if (!is_array($wizard['tt_content_defValues'] ?? false)) {
+                continue;
+            }
             foreach($wizard['tt_content_defValues'] as $columnName => $defaultValue) {
                 if (!in_array($columnName, ['CType', 'list_type'])) {
                     unset($wizards[$index]['tt_content_defValues'][$columnName]);


### PR DESCRIPTION
The function WizardController::keepOnlyListTypeAndCTypeInDefaultValues iterates over the wizard arrays. Perform checks to make sure values are set and will not result in exception.

Resolves: #18